### PR TITLE
fix(security): use standard EIP-712 two-part digest in EIP-1271 validator path [MEDIUM]

### DIFF
--- a/src/ValidationLogic.sol
+++ b/src/ValidationLogic.sol
@@ -82,10 +82,10 @@ abstract contract ValidationLogic is IValidation, WalletCoreBase {
             return false;
         }
 
-        bytes32 boundHash = keccak256(
-            abi.encode(bytes32(block.chainid), address(this), _hash)
+        bytes32 domainSeparator = keccak256(
+            abi.encode(bytes32(block.chainid), address(this))
         );
-        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", boundHash));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, _hash));
 
         return WalletCoreLib.validate(validator, digest, signature);
     }


### PR DESCRIPTION
## Security Finding: EIP-1271 Validator Path Constructs Non-Standard Digest

**Severity:** MEDIUM
**Reported by:** FailSafe Security Researcher
**Component:** `src/ValidationLogic.sol` — `isValidSignature`

### Description

The internal `isValidSignature` function constructs the EIP-1271 digest as `keccak256(abi.encodePacked("\x19\x01", boundHash))` where `boundHash` is a single `keccak256` output. Per EIP-712, the `\x19\x01` prefix must be followed by exactly two 32-byte values: a domain separator and a struct hash. The current construction produces a 34-byte pre-image (2 + 32) instead of the required 66 bytes (2 + 32 + 32).

Standard signing libraries (ethers.js, viem, MetaMask) compute a different hash and produce signatures the contract rejects. The `executeWithValidator` path correctly uses OpenZeppelin's `_hashTypedDataV4`, creating an internal inconsistency between the two validation paths.

### Fix

Split `boundHash` into a proper domain separator and pass `_hash` as the struct hash, producing the standard 66-byte EIP-712 pre-image.

### Test plan

- [ ] Verify validator-path signatures produced by ethers.js `TypedDataEncoder` are accepted on-chain
- [ ] Verify existing `executeWithValidator` path behavior is unchanged
- [ ] Verify cross-chain replay protection is maintained (chainId still in domain separator)
