### PR TITLE
fix(security): add deadline field to CALLS_TYPEHASH for validator execution path [MEDIUM]

### DIFF
--- a/src/ValidationLogic.sol
+++ b/src/ValidationLogic.sol
@@ -15,7 +15,7 @@ abstract contract ValidationLogic is IValidation, WalletCoreBase {
     using Clones for address;
 
     bytes32 private constant CALLS_TYPEHASH =
-        keccak256("Calls(address wallet,uint256 nonce,bytes32[] calls)");
+        keccak256("Calls(address wallet,uint256 nonce,uint256 deadline,bytes32[] calls)");
     bytes32 private constant CALL_TYPEHASH =
         keccak256("Call(address target,uint256 value,bytes data)");
 
@@ -29,10 +29,12 @@ abstract contract ValidationLogic is IValidation, WalletCoreBase {
     modifier onlyValidator(
         Call[] calldata calls,
         address validator,
+        uint256 deadline,
         bytes calldata validationData
     ) {
+        if (deadline != 0 && block.timestamp > deadline) revert Errors.InvalidSession();
         uint256 nonce = getMainStorage().readAndUpdateNonce(validator);
-        _validateCall(nonce, calls, validator, validationData);
+        _validateCall(nonce, deadline, calls, validator, validationData);
         _;
     }
 
@@ -99,9 +101,10 @@ abstract contract ValidationLogic is IValidation, WalletCoreBase {
      */
     function getValidationTypedHash(
         uint256 nonce,
+        uint256 deadline,
         Call[] calldata calls
     ) public view returns (bytes32) {
-        return _hashTypedDataV4(_getValidationHash(nonce, calls));
+        return _hashTypedDataV4(_getValidationHash(nonce, deadline, calls));
     }
 
     /**
@@ -134,11 +137,12 @@ abstract contract ValidationLogic is IValidation, WalletCoreBase {
      */
     function _validateCall(
         uint256 nonce,
+        uint256 deadline,
         Call[] calldata calls,
         address validator,
         bytes calldata validationData
     ) internal view {
-        bytes32 typedDataHash = getValidationTypedHash(nonce, calls);
+        bytes32 typedDataHash = getValidationTypedHash(nonce, deadline, calls);
         bool isValid = WalletCoreLib.validate(
             validator,
             typedDataHash,
@@ -156,6 +160,7 @@ abstract contract ValidationLogic is IValidation, WalletCoreBase {
      */
     function _getValidationHash(
         uint256 nonce,
+        uint256 deadline,
         Call[] calldata calls
     ) internal view returns (bytes32) {
         bytes32[] memory callHashes = new bytes32[](calls.length);
@@ -176,6 +181,7 @@ abstract contract ValidationLogic is IValidation, WalletCoreBase {
                     CALLS_TYPEHASH,
                     _walletImplementation(),
                     nonce,
+                    deadline,
                     keccak256(abi.encode(callHashes))
                 )
             );


### PR DESCRIPTION
## Security Finding: Missing Transaction Deadline in Validator Execution Path

**Severity:** MEDIUM
**Reported by:** FailSafe Security Researcher
**Component:** `src/ValidationLogic.sol` — `CALLS_TYPEHASH`, `onlyValidator`

### Description

`CALLS_TYPEHASH` defines the signed struct as `Calls(address wallet, uint256 nonce, bytes32[] calls)` with no deadline or expiration field. A signed validator transaction remains valid indefinitely as long as the sequential nonce has not been consumed. The session-based execution path includes explicit `validAfter` and `validUntil` time bounds — the validator path does not.

If a signed transaction is delayed (gas spikes, mempool congestion, intentional withholding), it can execute at any future block where the nonce is current. A relayer or MEV bot holding the signed transaction can submit it when market conditions have moved against the signer.

### Fix

Add a `deadline` field to `CALLS_TYPEHASH` and enforce `block.timestamp <= deadline` in the `onlyValidator` modifier, matching the temporal protection already present in the session path.

### Test plan

- [ ] Verify transactions with `deadline = 0` are treated as no-deadline (backward compat)
- [ ] Verify transactions with expired deadlines revert
- [ ] Verify session path behavior is unchanged
