### PR TITLE
fix(security): use abi.encodePacked for EIP-712 array hashing [MEDIUM]

### DIFF
--- a/src/ValidationLogic.sol
+++ b/src/ValidationLogic.sol
@@ -176,7 +176,7 @@ abstract contract ValidationLogic is IValidation, WalletCoreBase {
                     CALLS_TYPEHASH,
                     _walletImplementation(),
                     nonce,
-                    keccak256(abi.encode(callHashes))
+                    keccak256(abi.encodePacked(callHashes))
                 )
             );
     }


### PR DESCRIPTION
## Security Finding: Non-Standard EIP-712 Array Encoding in Validator Hash

**Severity:** MEDIUM
**Reported by:** FailSafe Security Researcher
**Component:** `src/ValidationLogic.sol` — `_getValidationHash`

### Description

`_getValidationHash` encodes the `bytes32[] callHashes` array using `keccak256(abi.encode(callHashes))`. Solidity's `abi.encode` prepends a 32-byte offset pointer and 32-byte length field before the array elements. EIP-712 section 5.2 specifies array values are encoded as `keccak256` of the concatenation of their `encodeData` results — meaning `abi.encodePacked`, not `abi.encode`.

The `abi.encode` form produces a `64 + 32*N` byte pre-image. The spec-compliant `abi.encodePacked` form produces `32*N` bytes. These are different hashes. No standard signing library can produce valid signatures for the `executeWithValidator` path.

### Fix

Replace `keccak256(abi.encode(callHashes))` with `keccak256(abi.encodePacked(callHashes))` to conform to EIP-712 array encoding.

### Test plan

- [ ] Verify on-chain hash matches ethers.js `TypedDataEncoder` output for multi-call transactions
- [ ] Verify single-call and empty-call edge cases produce correct hashes
- [ ] Verify existing test suite is updated to use standard encoding